### PR TITLE
removed addslashes call from structured data product description

### DIFF
--- a/partials/product-rich-snippets.php
+++ b/partials/product-rich-snippets.php
@@ -1,6 +1,6 @@
 <?php
    $rs_title = $product->get_title();
-   $rs_description = addslashes(strip_tags($product->get_short_description() ? $product->get_short_description() : $product->get_description()));
+   $rs_description = strip_tags($product->get_short_description() ? $product->get_short_description() : $product->get_description());
    $rs_availability = 'https://schema.org/' . ( $product->is_in_stock() ? 'InStock' : 'OutOfStock' );
    $rs_price = $product->get_price();
    $rs_currency = get_woocommerce_currency();


### PR DESCRIPTION
addslashes() could create an error in the product description/short description output in structured data. I believe this is more of an issue with content entry in the product descriptions/short descriptions than it is w/ the string manipulation occurring in product-rich-snippets.php. The error was only occurring with the wellness shots product.