### PR TITLE
added Mag styles for anchor tag on woocommerce short-desc div

### DIFF
--- a/woocommerce/single-product/short-description.php
+++ b/woocommerce/single-product/short-description.php
@@ -28,6 +28,6 @@ if ( ! $short_description ) {
 }
 
 ?>
-<div class="woocommerce-product-details__short-description">
+<div class="woocommerce-product-details__short-description k-rte-content">
 	<?php echo $short_description; // WPCS: XSS ok. ?>
 </div>


### PR DESCRIPTION
the visiting links were not matching the rest of the custom template theme. found the woocommerce pph file and added the Mag css class to correct the issue.